### PR TITLE
Removed BOM identifier as it's not recommended for UTF-8.

### DIFF
--- a/LECmd/Program.cs
+++ b/LECmd/Program.cs
@@ -470,7 +470,7 @@ namespace LECmd
                         var outFile = Path.Combine(_fluentCommandLineParser.Object.JsonDirectory, outName);
 
 
-                        jsonOut = new StreamWriter(new FileStream(outFile,FileMode.OpenOrCreate,FileAccess.Write),Encoding.UTF8);
+                        jsonOut = new StreamWriter(new FileStream(outFile,FileMode.OpenOrCreate,FileAccess.Write),new UTF8Encoding(false));
                     }
 
                     if (_fluentCommandLineParser.Object.xHtmlDirectory?.Length > 0)


### PR DESCRIPTION
The exported JSON file contains a [UTF-8 Byte Order Mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8).

This can be problematic when loading the file into external tools, or parsing with other scripting languages.

The screenshot below shows the BOM at the start of the file.

![2021-02-28 - 10-58-05-798 - HxD](https://user-images.githubusercontent.com/1139365/109419207-3c784d00-79c4-11eb-8f7e-467736f90772.png)

I came across this when trying to parse the json in python, with the following code, and subsequent error:

![2021-02-28 - 13-03-54-933 - Code](https://user-images.githubusercontent.com/1139365/109419483-99283780-79c5-11eb-822f-fe7187880d3e.png)

The python fix is to just open the file with `with open("LECmd_Output-BOM.json", mode='r', encoding='utf-8-sig') as file_json:` Although I think the BOM could be removed with documentation stating the output is UTF-8.

This Pull Request keeps the UTF-8 encoding for the stream writer, without the BOM being applied.