### PR TITLE
add ref for Spectre.Console due to dotnet build failing on linux

### DIFF
--- a/LECmd/LECmd.csproj
+++ b/LECmd/LECmd.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="AlphaFS.New" Version="2.3.0" />  
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta2.21617.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta2.21617.1" />
+    <PackageReference Include="Spectre.Console" Version="0.44.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">


### PR DESCRIPTION
When building on Linux, compilation fails due to missing a reference to the Spectre.Console package. After adding this reference, the build succeeds.